### PR TITLE
Add validation case.

### DIFF
--- a/Oxbind.Test/Checks.cs
+++ b/Oxbind.Test/Checks.cs
@@ -27,6 +27,29 @@ namespace Maroontress.Oxbind.Test
         {
             var factory = new OxbinderFactory();
             var binder = factory.Of<T>();
+            ThrowBindException<T>(binder, xml, message);
+        }
+
+        /// <summary>
+        /// Checks the <see cref="BindException"/> that
+        /// <see cref="Oxbinder{T}.NewInstance(TextReader)"/>
+        /// with the specified XML document throws.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The class associated with the root element.
+        /// </typeparam>
+        /// <param name="binder">
+        /// The <see cref="Oxbinder{T}"/> instance.
+        /// </param>
+        /// <param name="xml">
+        /// The XML document.
+        /// </param>
+        /// <param name="message">
+        /// The expected message that the <see cref="BindException"/> contains.
+        /// </param>
+        public static void ThrowBindException<T>(
+            Oxbinder<T> binder, string xml, string message)
+        {
             var reader = new StringReader(xml);
             try
             {

--- a/Oxbind.Test/MissingElementSchemaWarningTest.cs
+++ b/Oxbind.Test/MissingElementSchemaWarningTest.cs
@@ -1,0 +1,68 @@
+#pragma warning disable CS1591
+
+namespace Maroontress.Oxbind.Test
+{
+    using System.Collections.Generic;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public sealed class MissingElementSchemaWarningTest
+    {
+        private const string Xml = ""
+            + "<content project=\"Oxbind.CSharp\">\r\n"
+            + "  <page id=\"index\" title=\"Oxbind.CSharp\" nav=\"Top\" />\r\n"
+            + "  <page id=\"releasenotes\" "
+                + "title=\"Release Notes | Oxbind.CSharp\" "
+                + "nav=\"Release Notes\" />\r\n"
+            + "</content>\r\n";
+
+        [TestMethod]
+        public void CaseIgnoreWarnings()
+        {
+            var f = new OxbinderFactory(true);
+            var b = f.Of<Content>();
+            var m = "2:4: unexpected node type: Element of the element 'page' "
+                + "(it is expected that the element 'content' ends)";
+            Checks.ThrowBindException(b, Xml, m);
+        }
+
+        [TestMethod]
+        public void CaseTreatWarningsAsErrors()
+        {
+            var m = "Content has failed to validate annotations: "
+                + "Content: Warning: The field annotated with [ForChild] or "
+                + "the method annotated with [FromChild] is found without "
+                + "the static field annotated with [ElementSchema] (probably "
+                + "missing [ElementSchema] annotation): "
+                + "<Pages>k__BackingField";
+            Checks.ThrowBindException<Content>(Xml, m);
+        }
+
+        [ForElement("content")]
+        private sealed class Content
+        {
+            // [ElementSchema]
+            public static readonly Schema TheSchema = Schema.Of(
+                Multiple.Of<Page>());
+
+            [field: ForAttribute("project")]
+            public string Project { get; }
+
+            [field: ForChild]
+            public IEnumerable<Page> Pages { get; }
+        }
+
+        [ForElement("page")]
+        private sealed class Page
+        {
+            [field: ForAttribute("id")]
+            public string Id { get; }
+
+            [field: ForAttribute("title")]
+            public string Title { get; }
+
+            [field: ForAttribute("nav")]
+            public string Nav { get; }
+        }
+    }
+}

--- a/Oxbind.Test/Oxbind.Test.csproj
+++ b/Oxbind.Test/Oxbind.Test.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="ReportGenerator" Version="4.1.4" />
     <PackageReference Include="StyleChecker" Version="1.0.22" PrivateAssets="All" />
     <PackageReference Include="StyleChecker.Annotations" Version="1.0.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.114" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Oxbind/Maroontress/Oxbind/Impl/Resource.Designer.cs
+++ b/Oxbind/Maroontress/Oxbind/Impl/Resource.Designer.cs
@@ -20,7 +20,7 @@ namespace Maroontress.Oxbind.Impl {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resource {
@@ -220,6 +220,15 @@ namespace Maroontress.Oxbind.Impl {
         internal static string FromText_is_ignored {
             get {
                 return ResourceManager.GetString("FromText_is_ignored", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field annotated with [ForChild] or the method annotated with [FromChild] is found without the static field annotated with [ElementSchema] (probably missing [ElementSchema] annotation): {0}.
+        /// </summary>
+        internal static string missing_ElementSchema {
+            get {
+                return ResourceManager.GetString("missing_ElementSchema", resourceCulture);
             }
         }
         

--- a/Oxbind/Maroontress/Oxbind/Impl/Resource.resx
+++ b/Oxbind/Maroontress/Oxbind/Impl/Resource.resx
@@ -204,4 +204,7 @@
   <data name="type_mismatch_FromText" xml:space="preserve">
     <value>the type of the method annotated with [FromText] is not void(string): {0}</value>
   </data>
+  <data name="missing_ElementSchema" xml:space="preserve">
+    <value>The field annotated with [ForChild] or the method annotated with [FromChild] is found without the static field annotated with [ElementSchema] (probably missing [ElementSchema] annotation): {0}</value>
+  </data>
 </root>

--- a/Oxbind/Maroontress/Oxbind/OxbinderFactory.cs
+++ b/Oxbind/Maroontress/Oxbind/OxbinderFactory.cs
@@ -32,16 +32,25 @@ namespace Maroontress.Oxbind
         /// Initializes a new instance of the <see cref="OxbinderFactory"/>
         /// class.
         /// </summary>
-        public OxbinderFactory()
+        /// <param name="ignoreWarnings">
+        /// If the value is <c>true</c>, the <see
+        /// cref="OxbinderFactory.Of{T}"/> ignores warning messages to the
+        /// annotations of type <c>T</c>. Otherwise, the warning messages are
+        /// treated as errors, and then the method throws <see
+        /// cref="BindException"/>.
+        /// </param>
+        public OxbinderFactory(bool ignoreWarnings = false)
         {
             metadataCache = new InternMap<Type, Metadata>();
             validationTraversal = new Traversal<Type>(type =>
             {
                 var v = new Validator(type);
-                if (!v.IsValid)
+                var messages = v.GetMessages();
+                if (!v.IsValid
+                    || (!ignoreWarnings && messages.Any()))
                 {
                     var log = string.Join(
-                        Environment.NewLine, v.GetMessages());
+                        Environment.NewLine, messages);
                     throw new BindException(
                         $"{type.Name} has failed to validate annotations: "
                             + $"{log}");

--- a/Oxbind/Oxbind.csproj
+++ b/Oxbind/Oxbind.csproj
@@ -45,7 +45,7 @@
   <ItemGroup>
     <PackageReference Include="StyleChecker" Version="1.0.22" PrivateAssets="all" />
     <PackageReference Include="StyleChecker.Annotations" Version="1.0.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.114" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update dependencies.
- Add a new warning emitted when no static fieild annotated with
  [ElementSchema] found but the field with [ForChild] or the method
  with [FromChild] is found.
- Fix the constructor OxbindFactory() to take a parameter to control
  warnings messages.
- Fix the Unused [ForChild]/[FromChild] warning to be emitted only when
  there are one or more static fileds annotated with [ElementSchema].